### PR TITLE
OSV-11083 : Upgrade guava version to 32.0.1-jre to fix CVE-2023-2976

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,17 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>27.0-jre</version>
+            <version>32.0.1-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>3.33.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.j2objc</groupId>
+            <artifactId>j2objc-annotations</artifactId>
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>org.threeten</groupId>


### PR DESCRIPTION
This patch was tested locally.