### PR TITLE
OSV-11073 : Upgrade protobuf-java and protobuf-java-util version to 3.25.5 to fix CVE-2024-7254

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,16 @@
                 <artifactId>grpc-google-cloud-pubsublite-v1</artifactId>
                 <version>1.11.1</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.25.5</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java-util</artifactId>
+                <version>3.25.5</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This patch was tested locally.